### PR TITLE
Vendor catch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/fsm/test/catch.h linguist-vendored


### PR DESCRIPTION
This makes linguist detect the repo correctly as C++.