### PR TITLE
Fix custom graph printers

### DIFF
--- a/src/fsm/include/fsm/edge.h
+++ b/src/fsm/include/fsm/edge.h
@@ -111,6 +111,14 @@ public:
   /**
    * Get a DOT formatted representation of this edge.
    *
+   * The returned string can be used in a graphviz graph. This overload uses a
+   * custom printing function to print edge labels.
+   */
+  std::string Dot(std::function<std::string (T)> printer) const;
+
+  /**
+   * Get a DOT formatted representation of this edge.
+   *
    * The returned string can be used in a graphviz graph.
    */
   std::string Dot() const;
@@ -133,19 +141,28 @@ bool Edge<T>::Accepts(T val) const
 }
 
 template<class T>
-std::string Edge<T>::Dot() const {
+std::string Edge<T>::Dot(std::function<std::string (T)> printer) const {
   std::stringstream out;
 
   out << "\"" << end_->name << "\"";
   out << " [label=\"  ";
   if(edge_value_) {
-    out << *edge_value_;
+    out << printer(*edge_value_);
   } else {
     out << "&#949;";
   }
   out << "\"]";
 
   return out.str();
+}
+
+template<class T>
+std::string Edge<T>::Dot() const {
+  return Dot([](auto t) {
+    std::stringstream ss;
+    ss << t;
+    return ss.str();
+  });
 }
 
 // TODO: this dereferences the edge value, meaning that it will crash when

--- a/src/fsm/include/fsm/fsm.h
+++ b/src/fsm/include/fsm/fsm.h
@@ -700,7 +700,7 @@ std::string FiniteStateMachine<T>::Dot(std::function<std::string (T)> printer) c
   for(const auto& adj_list : adjacency_) {
     out << "  " << adj_list.first->Dot() << '\n';
     for(const auto& edge : adj_list.second) {
-      out << "  \"" << adj_list.first->name << "\" -> " << edge.Dot() << "\n";
+      out << "  \"" << adj_list.first->name << "\" -> " << edge.Dot(printer) << "\n";
     }
   }
   out << "}";


### PR DESCRIPTION
DOT output functions will no longer ignore custom printer arguments they
are passed.